### PR TITLE
Update SimpleArrayImplementationofStack.c

### DIFF
--- a/src/Chapter_04_Stacks/SimpleArrayImplementationofStack.c
+++ b/src/Chapter_04_Stacks/SimpleArrayImplementationofStack.c
@@ -26,8 +26,10 @@ struct SimpleArrayStack *CreateStack(){
     S->top = -1;
     S->array = malloc(S->capacity * sizeof(int));	// allocate an array of size 1 initially
 
-    if(!S->array) 
+    if(!S->array){
+        free(S);
         return NULL;
+    }
     return S;
 }
 


### PR DESCRIPTION
Removed potential memory leak in CreateStack(). If malloc() for S->array failed, *S was never freed.